### PR TITLE
Increase Gargantua size to match Opposing Force

### DIFF
--- a/dlls/gargantua.cpp
+++ b/dlls/gargantua.cpp
@@ -768,7 +768,7 @@ void CGargantua::Spawn()
 	Precache();
 
 	SET_MODEL(ENT(pev), "models/garg.mdl");
-	UTIL_SetSize(pev, Vector(-32, -32, 0), Vector(32, 32, 64));
+	UTIL_SetSize(pev, Vector(-40, -40, 0), Vector(40, 40, 214));
 
 	pev->solid = SOLID_SLIDEBOX;
 	pev->movetype = MOVETYPE_STEP;


### PR DESCRIPTION
Garg size is increased in Opfor to allow hitting it with projectiles like shock beams and spores. Otherwise they just fly through the model unless you aim at the legs.

From the decompiled code:
```c++
  LODWORD(v11.x) = 1109393408;
  LODWORD(v11.y) = 1109393408;
  LODWORD(v11.z) = 1129709568;
  LODWORD(v10.x) = -1038090240;
  LODWORD(v10.y) = -1038090240;
  LODWORD(v10.z) = 0;
```

Which translates to 40, 40, 214 and -40, -40, 0 in floats.
