### PR TITLE
Fix Gonome not using the secondary melee attack against player

### DIFF
--- a/dlls/gonome.cpp
+++ b/dlls/gonome.cpp
@@ -830,7 +830,7 @@ void COFGonome::SetActivity(Activity NewActivity)
 	case ACT_MELEE_ATTACK1:
 		if (m_hEnemy)
 		{
-			if ((pev->origin - m_hEnemy->pev->origin).Length() >= 48)
+			if ((pev->origin - m_hEnemy->pev->origin).Length2D() >= 48)
 			{
 				iSequence = LookupSequence("attack1");
 			}


### PR DESCRIPTION
The original opfor code used `Length2D` when checking for distance

```c++
    v8 = v6->origin.x - v7->origin.x;
    v9 = v8 * v8;
    v10 = v6->origin.y - v7->origin.y;
    if ( sqrt(v9 + v10 * v10) >= 48.0 )
    {
      v4 = 30;
      v11 = CBaseAnimating::LookupSequence(&this->baseclass_0.baseclass_0.baseclass_0, "attack1");
    }
```