### PR TITLE
fix m249 crouched spread turning off even when crouched

### DIFF
--- a/dlls/weapons/CM249.cpp
+++ b/dlls/weapons/CM249.cpp
@@ -178,7 +178,7 @@ void CM249::PrimaryAttack()
 
 	if (UTIL_IsMultiplayer())
 	{
-		if ((m_pPlayer->pev->button & IN_DUCK) != 0)
+		if (FBitSet(m_pPlayer->pev->flags, FL_DUCKING) && FBitSet(m_pPlayer->pev->flags, FL_ONGROUND))
 		{
 			vecSpread = VECTOR_CONE_3DEGREES;
 		}
@@ -196,7 +196,7 @@ void CM249::PrimaryAttack()
 	}
 	else
 	{
-		if ((m_pPlayer->pev->button & IN_DUCK) != 0)
+		if (FBitSet(m_pPlayer->pev->flags, FL_DUCKING) && FBitSet(m_pPlayer->pev->flags, FL_ONGROUND))
 		{
 			vecSpread = VECTOR_CONE_2DEGREES;
 		}


### PR DESCRIPTION
the m249 spread is reduced when crouching, but only if the button is pressed. This means that if the player is in a vent or any other spot that forces you to stay crouching and the player stops pressing the crouch button, the spread will use the walking/stationary accuracy instead of crouching accuracy.

This also makes it so you cannot get the crouch benefit while in air. 

If I feel like it I'll add another if for just normally walking and not running